### PR TITLE
Clean Shutdown: Handle drain command; send websocket close frame

### DIFF
--- a/lib/idl/cherami.thrift
+++ b/lib/idl/cherami.thrift
@@ -95,7 +95,13 @@ enum DestinationType {
    * Each message has associated sequence number. Sequence numbers are guaranteed to be sequential.
    * Messages with incorrect sequence number provided by publisher are rejected.
   **/
-  LOG
+  LOG,
+  
+  /**
+   * PLAIN destination backed with Kafka storage
+   *
+  **/
+  KAFKA
 }
 
 enum ConsumerGroupType {
@@ -143,6 +149,8 @@ struct DestinationDescription {
  10: optional bool isMultiZone
  11: optional DestinationZoneConfigs zoneConfigs
  20: optional SchemaInfo schemaInfo // Latest schema for this destination
+ 40: optional string kafkaCluster
+ 41: optional list<string> kafkaTopics
 }
 
 struct SchemaInfo {
@@ -176,6 +184,8 @@ struct CreateDestinationRequest {
  10: optional bool isMultiZone
  11: optional DestinationZoneConfigs zoneConfigs
  20: optional SchemaInfo schemaInfo
+ 40: optional string kafkaCluster
+ 41: optional list<string> kafkaTopics
 }
 
 struct ReadDestinationRequest {
@@ -550,7 +560,8 @@ struct ReconfigureInfo {
 
 enum InputHostCommandType {
   ACK,
-  RECONFIGURE
+  RECONFIGURE,
+  DRAIN // to trigger draining of a all connections to this inputhost on this publisher object
 }
 
 struct InputHostCommand {

--- a/lib/src/main/java/com/uber/cherami/client/CheramiClientSocket.java
+++ b/lib/src/main/java/com/uber/cherami/client/CheramiClientSocket.java
@@ -100,6 +100,19 @@ public class CheramiClientSocket {
         session.getRemote().sendBytes(ByteBuffer.wrap(msg));
     }
 
+    /**
+     * Close initiates graceful shutdown of the underlying websocket session.
+     */
+    public void close() {
+        try {
+            if (session != null) {
+                session.close();
+            }
+        } catch (Exception e) {
+            logger.error("Error closing websocket connection", e);
+        }
+    }
+
     @OnWebSocketMessage
     public void processUpload(Session session, byte[] input, int arg1, int arg2) {
         connection.receiveMessage(input);

--- a/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
+++ b/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
@@ -314,8 +314,13 @@ public class InputHostConnection implements Connection, WebsocketConnection, Run
         }
     }
 
+    /**
+     * Reads and processes upto limit acks from the ack queue.
+     *
+     * @param limit
+     *            Max number of acks to read and process.
+     */
     private void readProcessAcks(int limit) {
-        // Ack batch size messages if you can
         int numToAck = Math.min(ackedMessageQueue.size(), limit);
         for (int i = 0; i < numToAck; i++) {
             PutMessageAck ack = ackedMessageQueue.poll();

--- a/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
+++ b/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
@@ -69,6 +69,9 @@ public class InputHostConnection implements Connection, WebsocketConnection, Run
     private static final long DEFAULT_CONNECT_TIMEOUT_SECONDS = TimeUnit.MILLISECONDS
             .toSeconds(SelectorManager.DEFAULT_CONNECT_TIMEOUT) + 1;
 
+    /** Amount of time we wait for the threads to stop during shutdown. */
+    private static final long SHUTDOWN_TIMEOUT_MILLIS = 1000;
+
     private final String uri;
     private final String path;
 
@@ -177,7 +180,7 @@ public class InputHostConnection implements Connection, WebsocketConnection, Run
         if (isOpen.getAndSet(false)) {
             try {
                 countDownLatch.countDown();
-                if (stoppedLatch.await(1, TimeUnit.SECONDS)) {
+                if (stoppedLatch.await(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
                     // if the thread stopped successfully, then
                     // do a graceful drain of the ack queue
                     drainAcks(publisherOptions.writeTimeoutMillis);

--- a/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
+++ b/lib/src/main/java/com/uber/cherami/client/InputHostConnection.java
@@ -168,7 +168,7 @@ public class InputHostConnection implements Connection, WebsocketConnection, Run
      *
      *   (1) Stop new writes to the server
      *   (2) Drain all acks (or timeout)
-     *   (3) Stop all threads and close the socket
+     *   (3) Close the socket
      *
      * </pre>
      */

--- a/lib/src/main/java/com/uber/cherami/client/OutputHostConnection.java
+++ b/lib/src/main/java/com/uber/cherami/client/OutputHostConnection.java
@@ -210,6 +210,7 @@ public class OutputHostConnection implements WebsocketConnection, Connection, Ch
         if (isOpen.getAndSet(false)) {
             readMessagesPump.stop();
             writeAcksPump.stop();
+            socket.close();
             logger.info("Output host connection to {} closed", wsUrl);
         }
     }


### PR DESCRIPTION
This patch contains changes related to graceful shutdown of connections from client to input/output:

* Code to handle Reconfigure.DRAIN command from input host
* Currently, the client never explicitly sends a close frame on the websocket and always waits for the server to initiate the close. This works in practice, however, the right behavior will be to initiate the websocket.close as soon as the library calls close() on the publisher or consumer object. 